### PR TITLE
Auto-flush fake response writer

### DIFF
--- a/frontend/src/test/java/com/google/tripmeout/frontend/servlet/FakeHttpServletResponse.java
+++ b/frontend/src/test/java/com/google/tripmeout/frontend/servlet/FakeHttpServletResponse.java
@@ -231,7 +231,8 @@ public class FakeHttpServletResponse implements HttpServletResponse {
   public PrintWriter getWriter() throws IOException {
     checkState(outputStream == null, "getOutputStream() already called");
     if (printWriter == null) {
-      printWriter = new PrintWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
+      printWriter = new PrintWriter(
+          new OutputStreamWriter(output, StandardCharsets.UTF_8), /* autoFlush= */ true);
     }
     return printWriter;
   }


### PR DESCRIPTION
This allows the response writer to be used by servlets without explicit flushing.