### PR TITLE
fix PlaceVisitModel object fields, adjust storage interface

### DIFF
--- a/frontend/src/main/java/com/google/tripmeout/frontend/PlaceVisitModel.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/PlaceVisitModel.java
@@ -11,26 +11,22 @@ public abstract class PlaceVisitModel {
     return new AutoValue_PlaceVisitModel.Builder().setUserMark(UserMark.UNKNOWN);
   }
 
-  @Nullable public abstract String uuid();
+  @Nullable public abstract String id();
   public abstract String placesApiPlaceId();
   @Nullable public abstract String tripId();
   public abstract UserMark userMark();
-  // TO-DO: decide if we still need/want these fields
+  // TO-DO: decide if we still need/want this field
   @Nullable public abstract String placeName();
-  @Nullable public abstract Double latitude();
-  @Nullable public abstract Double longitude();
 
   public abstract Builder toBuilder();
 
   @AutoValue.Builder
   public static abstract class Builder {
-    public abstract Builder setUuid(String id);
+    public abstract Builder setId(String id);
     public abstract Builder setPlacesApiPlaceId(String placeId);
     public abstract Builder setPlaceName(String placeName);
     public abstract Builder setTripId(String tripId);
     public abstract Builder setUserMark(UserMark userMark);
-    public abstract Builder setLatitude(Double latitude);
-    public abstract Builder setLongitude(Double longitude);
     public abstract PlaceVisitModel build();
   }
 }

--- a/frontend/src/main/java/com/google/tripmeout/frontend/PlaceVisitModel.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/PlaceVisitModel.java
@@ -11,10 +11,12 @@ public abstract class PlaceVisitModel {
     return new AutoValue_PlaceVisitModel.Builder().setUserMark(UserMark.UNKNOWN);
   }
 
+  @Nullable public abstract String uuid();
   public abstract String placesApiPlaceId();
-  @Nullable public abstract String placeName();
-  public abstract String tripId();
+  @Nullable public abstract String tripId();
   public abstract UserMark userMark();
+  // TO-DO: decide if we still need/want these fields
+  @Nullable public abstract String placeName();
   @Nullable public abstract Double latitude();
   @Nullable public abstract Double longitude();
 
@@ -22,6 +24,7 @@ public abstract class PlaceVisitModel {
 
   @AutoValue.Builder
   public static abstract class Builder {
+    public abstract Builder setUuid(String id);
     public abstract Builder setPlacesApiPlaceId(String placeId);
     public abstract Builder setPlaceName(String placeName);
     public abstract Builder setTripId(String tripId);

--- a/frontend/src/main/java/com/google/tripmeout/frontend/serialization/GsonPlaceVisitTypeAdapter.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/serialization/GsonPlaceVisitTypeAdapter.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 
 public class GsonPlaceVisitTypeAdapter extends TypeAdapter<PlaceVisitModel> {
   private static final String PLACE_ID_JSON_FIELD_NAME = "placesApiPlaceId";
+  private static final String UUID_JSON_FIELD_NAME = "uuid";
   private static final String TRIP_ID_JSON_FIELD_NAME = "tripId";
   private static final String NAME_JSON_FIELD_NAME = "placeName";
   private static final String USER_MARK_JSON_FIELD_NAME = "userMark";
@@ -29,6 +30,9 @@ public class GsonPlaceVisitTypeAdapter extends TypeAdapter<PlaceVisitModel> {
     while (reader.hasNext()) {
       String name = reader.nextName();
       switch (name) {
+        case UUID_JSON_FIELD_NAME:
+          placeBuilder.setUuid(reader.nextString());
+          break;
         case PLACE_ID_JSON_FIELD_NAME:
           placeBuilder.setPlacesApiPlaceId(reader.nextString());
           break;
@@ -64,6 +68,7 @@ public class GsonPlaceVisitTypeAdapter extends TypeAdapter<PlaceVisitModel> {
       return;
     }
     writer.beginObject();
+    writeUnlessNullOrEmpty(writer, UUID_JSON_FIELD_NAME, place.uuid());
     writeUnlessNullOrEmpty(writer, PLACE_ID_JSON_FIELD_NAME, place.placesApiPlaceId());
     writeUnlessNullOrEmpty(writer, NAME_JSON_FIELD_NAME, place.placeName());
     writeUnlessNullOrEmpty(writer, TRIP_ID_JSON_FIELD_NAME, place.tripId());

--- a/frontend/src/main/java/com/google/tripmeout/frontend/serialization/GsonPlaceVisitTypeAdapter.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/serialization/GsonPlaceVisitTypeAdapter.java
@@ -12,12 +12,10 @@ import java.io.IOException;
 
 public class GsonPlaceVisitTypeAdapter extends TypeAdapter<PlaceVisitModel> {
   private static final String PLACE_ID_JSON_FIELD_NAME = "placesApiPlaceId";
-  private static final String UUID_JSON_FIELD_NAME = "uuid";
+  private static final String UUID_JSON_FIELD_NAME = "id";
   private static final String TRIP_ID_JSON_FIELD_NAME = "tripId";
   private static final String NAME_JSON_FIELD_NAME = "placeName";
   private static final String USER_MARK_JSON_FIELD_NAME = "userMark";
-  private static final String LATITUDE_JSON_FIELD_NAME = "latitude";
-  private static final String LONGITUDE_JSON_FIELD_NAME = "longitude";
 
   @Override
   public PlaceVisitModel read(JsonReader reader) throws IOException {
@@ -31,7 +29,7 @@ public class GsonPlaceVisitTypeAdapter extends TypeAdapter<PlaceVisitModel> {
       String name = reader.nextName();
       switch (name) {
         case UUID_JSON_FIELD_NAME:
-          placeBuilder.setUuid(reader.nextString());
+          placeBuilder.setId(reader.nextString());
           break;
         case PLACE_ID_JSON_FIELD_NAME:
           placeBuilder.setPlacesApiPlaceId(reader.nextString());
@@ -45,12 +43,6 @@ public class GsonPlaceVisitTypeAdapter extends TypeAdapter<PlaceVisitModel> {
         case USER_MARK_JSON_FIELD_NAME:
           UserMark userMark = UserMark.valueOf(reader.nextString());
           placeBuilder.setUserMark(userMark);
-          break;
-        case LATITUDE_JSON_FIELD_NAME:
-          placeBuilder.setLatitude(reader.nextDouble());
-          break;
-        case LONGITUDE_JSON_FIELD_NAME:
-          placeBuilder.setLongitude(reader.nextDouble());
           break;
         default:
           throw new JsonParseException(
@@ -68,16 +60,12 @@ public class GsonPlaceVisitTypeAdapter extends TypeAdapter<PlaceVisitModel> {
       return;
     }
     writer.beginObject();
-    writeUnlessNullOrEmpty(writer, UUID_JSON_FIELD_NAME, place.uuid());
+    writeUnlessNullOrEmpty(writer, UUID_JSON_FIELD_NAME, place.id());
     writeUnlessNullOrEmpty(writer, PLACE_ID_JSON_FIELD_NAME, place.placesApiPlaceId());
     writeUnlessNullOrEmpty(writer, NAME_JSON_FIELD_NAME, place.placeName());
     writeUnlessNullOrEmpty(writer, TRIP_ID_JSON_FIELD_NAME, place.tripId());
     writer.name(USER_MARK_JSON_FIELD_NAME);
     writer.value(place.userMark().toString());
-    writer.name(LATITUDE_JSON_FIELD_NAME);
-    writer.value(place.latitude());
-    writer.name(LONGITUDE_JSON_FIELD_NAME);
-    writer.value(place.longitude());
     writer.endObject();
   }
 

--- a/frontend/src/main/java/com/google/tripmeout/frontend/storage/InMemoryPlaceVisitStorage.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/storage/InMemoryPlaceVisitStorage.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class InMemoryPlaceVisitStorage implements PlaceVisitStorage {
   // <tripId, uuid, PlaceVisitModel>
@@ -63,29 +62,6 @@ public class InMemoryPlaceVisitStorage implements PlaceVisitStorage {
   public Optional<PlaceVisitModel> getPlaceVisit(String tripId, String placeUuid) {
     return Optional.ofNullable(placesByTripIdByPlaceId.get(tripId))
         .map(placesMap -> placesMap.get(placeUuid));
-  }
-
-  @Override
-  public PlaceVisitModel updateUserMark(String tripId, String placeUuid,
-      PlaceVisitModel.UserMark newStatus) throws PlaceVisitNotFoundException {
-    AtomicReference<PlaceVisitModel> updatedPlaceVisit = new AtomicReference();
-
-    placesByTripIdByPlaceId.computeIfPresent(tripId, (tripKey, placesMap) -> {
-      PlaceVisitModel placeVisit = placesMap.get(placeUuid);
-      if (placeVisit != null) {
-        PlaceVisitModel newPlaceVisit = placeVisit.toBuilder().setUserMark(newStatus).build();
-        placesMap.put(placeUuid, newPlaceVisit);
-        updatedPlaceVisit.set(newPlaceVisit);
-      }
-      return placesMap;
-    });
-
-    if (updatedPlaceVisit.get() == null) {
-      throw new PlaceVisitNotFoundException(
-          "PlaceVisit with id: '" + placeUuid + "' not found for trip '" + tripId + "'");
-    }
-
-    return updatedPlaceVisit.get();
   }
 
   @Override

--- a/frontend/src/main/java/com/google/tripmeout/frontend/storage/InMemoryPlaceVisitStorage.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/storage/InMemoryPlaceVisitStorage.java
@@ -45,21 +45,24 @@ public class InMemoryPlaceVisitStorage implements PlaceVisitStorage {
   }
 
   @Override
-  public void removePlaceVisit(String tripId, String placeUuid) throws PlaceVisitNotFoundException {
+  public void removePlaceVisit(String tripId, String placeVisitId)
+      throws PlaceVisitNotFoundException {
     Map<String, PlaceVisitModel> placesMap = placesByTripIdByPlaceId.get(tripId);
     if (placesMap == null) {
-      throw new PlaceVisitNotFoundException(String.format(("PlaceVisit with id '%s' not found for trip '%s'"), placeUuid, tripId));
+      throw new PlaceVisitNotFoundException(
+          String.format(("PlaceVisit with id '%s' not found for trip '%s'"), placeVisitId, tripId));
     }
 
-    if (placesMap.remove(placeUuid) == null) {
-      throw new PlaceVisitNotFoundException(String.format(("PlaceVisit with id '%s' not found for trip '%s'"), placeUuid, tripId));
+    if (placesMap.remove(placeVisitId) == null) {
+      throw new PlaceVisitNotFoundException(
+          String.format(("PlaceVisit with id '%s' not found for trip '%s'"), placeVisitId, tripId));
     }
   }
 
   @Override
-  public Optional<PlaceVisitModel> getPlaceVisit(String tripId, String placeUuid) {
+  public Optional<PlaceVisitModel> getPlaceVisit(String tripId, String placeVisitId) {
     return Optional.ofNullable(placesByTripIdByPlaceId.get(tripId))
-        .map(placesMap -> placesMap.get(placeUuid));
+        .map(placesMap -> placesMap.get(placeVisitId));
   }
 
   @Override

--- a/frontend/src/main/java/com/google/tripmeout/frontend/storage/PlaceVisitStorage.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/storage/PlaceVisitStorage.java
@@ -17,30 +17,45 @@ public interface PlaceVisitStorage {
    * @param placeVisit the PlaceVisitModel object to add to storage
    *
    * @throws a PlaceVisitAlreadyExists exception if there is a PlaceVisitModel
-   *     in storage with the same tripId and placeId as placeVisit
+   *     in storage with the same tripId and placeUuid as placeVisit
    */
   void addPlaceVisit(PlaceVisitModel placeVisit) throws PlaceVisitAlreadyExistsException;
 
   /**
-   * removes from storage the PlaceVisitModel whose tripId and placeId match the
-   * given tripId and placeId, respectively
+   * removes from storage the PlaceVisitModel whose tripId and placeUuid match the
+   * given tripId and placeUuid, respectively
    *
-   * @param tripId the id to match PlaceVisitModel object's placeId field on
-   * @param placeId the id to match PlaceVisitModel object's placeId field on
+   * @param tripId the id to match PlaceVisitModel object's tripId field on
+   * @param placeUuid the id to match PlaceVisitModel object's uuid field on
    *
    * @throws a PlaceVisitNotFound exception if there is no PlaceVisitModel
-   *     object in storage with the given tripId and placeId
+   *     object in storage with the given tripId and placeUuid
    */
-  void removePlaceVisit(String tripId, String placeId) throws PlaceVisitNotFoundException;
+  void removePlaceVisit(String tripId, String placeUuid) throws PlaceVisitNotFoundException;
 
   /**
-   * returns the PlaceVisitModel whose tripId and placeId match the given tripId
-   * and placeId, respectively
+   * returns the PlaceVisitModel whose tripId and placeUuid match the given tripId
+   * and placeUuid, respectively
    *
-   * @param tripId the id to match PlaceVisitModel object's placeId field on
-   * @param placeId the id to match PlaceVisitModel object's placeId field on
+   * @param tripId the id to match PlaceVisitModel object's tripId field on
+   * @param placeUuid the id to match PlaceVisitModel object's uuid field on
    */
-  Optional<PlaceVisitModel> getPlaceVisit(String tripId, String placeId);
+  Optional<PlaceVisitModel> getPlaceVisit(String tripId, String placeUuid);
+
+  /**
+   * updates the userMark parameter of the PlaceVisitModel object whose tripId
+   * and placeUuid match the given tripId and placeUuid, respectively,
+   * return the updated PlaceVisitModel
+   *
+   * @param tripId the id to match PlaceVisitModel object's tripId field on
+   * @param placeUuid the id to match PlaceVisitModel object's uuid field on
+   * @param newStatus the new status to update placeVisit's userMark field to
+   *
+   * @throws a PlaceVisitNotFound exception if there is no PlaceVisitModel
+   *     object in storage with the given tripId and placeUuid
+   */
+  PlaceVisitModel updateUserMark(String tripId, String placeUuid,
+      PlaceVisitModel.UserMark newStatus) throws PlaceVisitNotFoundException;
 
   /**
    * updates the userMark parameter of the PlaceVisitModel object whose tripId
@@ -60,7 +75,7 @@ public interface PlaceVisitStorage {
    * gets a list of all of the PlaceVisitModel objects whose tripId matches the
    * given tripId
    *
-   * @param tripId the id to match PlaceVisitModel object's placeId field on
+   * @param tripId the id to match PlaceVisitModel object's tripId field on
    */
   List<PlaceVisitModel> getTripPlaceVisits(String tripId);
 

--- a/frontend/src/main/java/com/google/tripmeout/frontend/storage/PlaceVisitStorage.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/storage/PlaceVisitStorage.java
@@ -44,21 +44,6 @@ public interface PlaceVisitStorage {
 
   /**
    * updates the userMark parameter of the PlaceVisitModel object whose tripId
-   * and placeUuid match the given tripId and placeUuid, respectively,
-   * return the updated PlaceVisitModel
-   *
-   * @param tripId the id to match PlaceVisitModel object's tripId field on
-   * @param placeUuid the id to match PlaceVisitModel object's uuid field on
-   * @param newStatus the new status to update placeVisit's userMark field to
-   *
-   * @throws a PlaceVisitNotFound exception if there is no PlaceVisitModel
-   *     object in storage with the given tripId and placeUuid
-   */
-  PlaceVisitModel updateUserMark(String tripId, String placeUuid,
-      PlaceVisitModel.UserMark newStatus) throws PlaceVisitNotFoundException;
-
-  /**
-   * updates the userMark parameter of the PlaceVisitModel object whose tripId
    * and placeId match the given tripId and placeId, respectively,
    * if PlaceVisitModel obbject in storage
    * adds PlaceVisitModel object otherwise

--- a/frontend/src/main/java/com/google/tripmeout/frontend/storage/PlaceVisitStorage.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/storage/PlaceVisitStorage.java
@@ -17,30 +17,30 @@ public interface PlaceVisitStorage {
    * @param placeVisit the PlaceVisitModel object to add to storage
    *
    * @throws a PlaceVisitAlreadyExists exception if there is a PlaceVisitModel
-   *     in storage with the same tripId and placeUuid as placeVisit
+   *     in storage with the same tripId and placeId as placeVisit
    */
   void addPlaceVisit(PlaceVisitModel placeVisit) throws PlaceVisitAlreadyExistsException;
 
   /**
-   * removes from storage the PlaceVisitModel whose tripId and placeUuid match the
-   * given tripId and placeUuid, respectively
+   * removes from storage the PlaceVisitModel whose tripId and place visit id match the
+   * given tripId and place id, respectively
    *
    * @param tripId the id to match PlaceVisitModel object's tripId field on
-   * @param placeUuid the id to match PlaceVisitModel object's uuid field on
+   * @param placeVisitId the id to match PlaceVisitModel object's id field on
    *
    * @throws a PlaceVisitNotFound exception if there is no PlaceVisitModel
-   *     object in storage with the given tripId and placeUuid
+   *     object in storage with the given tripId and place visit id
    */
-  void removePlaceVisit(String tripId, String placeUuid) throws PlaceVisitNotFoundException;
+  void removePlaceVisit(String tripId, String placeVisitId) throws PlaceVisitNotFoundException;
 
   /**
-   * returns the PlaceVisitModel whose tripId and placeUuid match the given tripId
-   * and placeUuid, respectively
+   * returns the PlaceVisitModel whose tripId and place visit id match the given tripId
+   * and place visit id, respectively
    *
    * @param tripId the id to match PlaceVisitModel object's tripId field on
-   * @param placeUuid the id to match PlaceVisitModel object's uuid field on
+   * @param placeVisitId the id to match PlaceVisitModel object's id field on
    */
-  Optional<PlaceVisitModel> getPlaceVisit(String tripId, String placeUuid);
+  Optional<PlaceVisitModel> getPlaceVisit(String tripId, String placeVisitId);
 
   /**
    * updates the userMark parameter of the PlaceVisitModel object whose tripId

--- a/frontend/src/test/java/com/google/sps/InMemoryPlaceVisitStorageTest.java
+++ b/frontend/src/test/java/com/google/sps/InMemoryPlaceVisitStorageTest.java
@@ -19,6 +19,7 @@ import org.junit.runners.JUnit4;
 public final class InMemoryPlaceVisitStorageTest {
   // PlaceVisitModel objects to use in testing
   private static final PlaceVisitModel LONDON = PlaceVisitModel.builder()
+                                                    .setUuid("LCY, London")
                                                     .setPlacesApiPlaceId("LCY")
                                                     .setPlaceName("London, UK")
                                                     .setTripId("a")
@@ -28,6 +29,7 @@ public final class InMemoryPlaceVisitStorageTest {
                                                     .build();
 
   private static final PlaceVisitModel ROME = PlaceVisitModel.builder()
+                                                  .setUuid("FCO, Rome")
                                                   .setPlacesApiPlaceId("FCO")
                                                   .setPlaceName("Rome, Italy")
                                                   .setTripId("a")
@@ -37,6 +39,7 @@ public final class InMemoryPlaceVisitStorageTest {
                                                   .build();
 
   private static final PlaceVisitModel PARIS = PlaceVisitModel.builder()
+                                                   .setUuid("CDG, Paris")
                                                    .setPlacesApiPlaceId("CDG")
                                                    .setPlaceName("Paris, France")
                                                    .setTripId("a")
@@ -46,6 +49,7 @@ public final class InMemoryPlaceVisitStorageTest {
                                                    .build();
 
   private static final PlaceVisitModel TOKYO = PlaceVisitModel.builder()
+                                                   .setUuid("HND, Tokyo")
                                                    .setPlacesApiPlaceId("HND")
                                                    .setPlaceName("Tokyo, Japan")
                                                    .setTripId("a")
@@ -55,6 +59,7 @@ public final class InMemoryPlaceVisitStorageTest {
                                                    .build();
 
   private static final PlaceVisitModel BEIJING = PlaceVisitModel.builder()
+                                                     .setUuid("PEK, Beijing")
                                                      .setPlacesApiPlaceId("PEK")
                                                      .setPlaceName("Beijing, China")
                                                      .setTripId("b")
@@ -64,6 +69,7 @@ public final class InMemoryPlaceVisitStorageTest {
                                                      .build();
 
   private static final PlaceVisitModel SEOUL = PlaceVisitModel.builder()
+                                                   .setUuid("ICN, Seoul")
                                                    .setPlacesApiPlaceId("ICN")
                                                    .setPlaceName("Seoul, South Korea")
                                                    .setTripId("b")
@@ -73,6 +79,7 @@ public final class InMemoryPlaceVisitStorageTest {
                                                    .build();
 
   private static final PlaceVisitModel TOKYO_B = PlaceVisitModel.builder()
+                                                     .setUuid("HND, Tokyo")
                                                      .setPlacesApiPlaceId("HND")
                                                      .setPlaceName("Tokyo, Japan")
                                                      .setTripId("b")
@@ -82,6 +89,7 @@ public final class InMemoryPlaceVisitStorageTest {
                                                      .build();
 
   private static final PlaceVisitModel SEOUL_B = PlaceVisitModel.builder()
+                                                     .setUuid("ICN, Seoul")
                                                      .setPlacesApiPlaceId("ICN")
                                                      .setPlaceName("some city in Korea")
                                                      .setTripId("b")
@@ -92,7 +100,7 @@ public final class InMemoryPlaceVisitStorageTest {
 
   /**
    * test that a PlaceVisitAlreadyExistsException is thrown when a place is
-   * added but another place with the same PlacesApiPlaceId and tripId has already
+   * added but another place with the same uuid and tripId has already
    * been added to the storage
    */
   @Test
@@ -111,13 +119,13 @@ public final class InMemoryPlaceVisitStorageTest {
   @Test
   public void getPlaceVisit_emptyStorage_returnsEmptyOptional() {
     InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
-    assertThat(storage.getPlaceVisit(TOKYO.tripId(), TOKYO.placesApiPlaceId())).isEmpty();
+    assertThat(storage.getPlaceVisit(TOKYO.tripId(), TOKYO.uuid())).isEmpty();
   }
 
   /**
    * test that a PlaceNotFoundException is thrown when trying to get a place
    * from storage when there is no place in storage with the given tripId and
-   * PlacesApiPlaceId
+   * uuid
    */
   @Test
   public void getPlaceVisit_placeNotInStorage_returnsEmptyOptional()
@@ -125,7 +133,7 @@ public final class InMemoryPlaceVisitStorageTest {
     InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
     storage.addPlaceVisit(TOKYO);
     storage.addPlaceVisit(TOKYO_B);
-    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.placesApiPlaceId())).isEmpty();
+    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.uuid())).isEmpty();
   }
 
   /**
@@ -140,11 +148,11 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(TOKYO_B);
 
     Optional<PlaceVisitModel> tokyo =
-        storage.getPlaceVisit(TOKYO.tripId(), TOKYO.placesApiPlaceId());
+        storage.getPlaceVisit(TOKYO.tripId(), TOKYO.uuid());
     assertThat(tokyo).hasValue(TOKYO);
 
     Optional<PlaceVisitModel> tokyoB =
-        storage.getPlaceVisit(TOKYO_B.tripId(), TOKYO_B.placesApiPlaceId());
+        storage.getPlaceVisit(TOKYO_B.tripId(), TOKYO_B.uuid());
     assertThat(tokyoB).hasValue(TOKYO_B);
   }
 
@@ -156,13 +164,13 @@ public final class InMemoryPlaceVisitStorageTest {
   public void removePlaceVisit_emptyStorage_throwsException() throws PlaceVisitNotFoundException {
     InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
     Assert.assertThrows(PlaceVisitNotFoundException.class,
-        () -> storage.removePlaceVisit(TOKYO.tripId(), TOKYO.placesApiPlaceId()));
+        () -> storage.removePlaceVisit(TOKYO.tripId(), TOKYO.uuid()));
   }
 
   /**
    * test that a PlaceNotFoundException is thrown when trying to remove a place
    * from storage when there is no place in storage with the given tripId and
-   * placesApiPlaceId
+   * uuid
    */
   @Test
   public void removePlaceVisit_placeNotInStorage_throwsException()
@@ -171,12 +179,12 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(TOKYO);
     storage.addPlaceVisit(TOKYO_B);
     Assert.assertThrows(PlaceVisitNotFoundException.class,
-        () -> storage.removePlaceVisit(SEOUL.tripId(), SEOUL.placesApiPlaceId()));
+        () -> storage.removePlaceVisit(SEOUL.tripId(), SEOUL.uuid()));
   }
 
   /**
    * test that no exception is thrown when removing a place from storage when
-   * there is a place in storage with the given tripId and placesApiPlaceId
+   * there is a place in storage with the given tripId and uuid
    */
   @Test
   public void removePlace_placeInStorage_noException()
@@ -184,13 +192,13 @@ public final class InMemoryPlaceVisitStorageTest {
     InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
     storage.addPlaceVisit(ROME);
     storage.addPlaceVisit(BEIJING);
-    storage.removePlaceVisit(ROME.tripId(), ROME.placesApiPlaceId());
+    storage.removePlaceVisit(ROME.tripId(), ROME.uuid());
   }
 
   /**
    * test that place is actually removed when removing a place from storage when
-   * there is a place in storage with the given tripId and placesApiPlaceId by checking
-   * that calling getPlaceVisit on the removed PlaceVisit tripId and placesApiPlaceId
+   * there is a place in storage with the given tripId and uuid by checking
+   * that calling getPlaceVisit on the removed PlaceVisit tripId and uuid
    * results in PlaceVisitNotFoundException being thrown
    */
   @Test
@@ -199,13 +207,14 @@ public final class InMemoryPlaceVisitStorageTest {
     InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
     storage.addPlaceVisit(ROME);
     storage.addPlaceVisit(BEIJING);
-    storage.removePlaceVisit(ROME.tripId(), ROME.placesApiPlaceId());
-    assertThat(storage.getPlaceVisit(ROME.tripId(), ROME.placesApiPlaceId())).isEmpty();
+    storage.removePlaceVisit(ROME.tripId(), ROME.uuid());
+    assertThat(storage.getPlaceVisit(ROME.tripId(), ROME.uuid())).isEmpty();
   }
 
   /**
-   * test that changePlaceVisitStatus returns true and changes userMark field
-   * when PlaceVisitModel object with the given tripId and placesApiPlaceId is in storage
+   * test that updateUserMarkOrAddPlaceVisit returns true and changes userMark field
+   * and returns true when PlaceVisitModel object with the given tripId and
+   * uuid is in storage
    */
   @Test
   public void updateUserMarkOrAddPlaceVisit_placeInStorage_returnsTrueAndStatusChanged()
@@ -218,14 +227,14 @@ public final class InMemoryPlaceVisitStorageTest {
 
     boolean response = storage.updateUserMarkOrAddPlaceVisit(PARIS, PlaceVisitModel.UserMark.NO);
     PlaceVisitModel changedParis =
-        storage.getPlaceVisit(PARIS.tripId(), PARIS.placesApiPlaceId()).get();
+        storage.getPlaceVisit(PARIS.tripId(), PARIS.uuid()).get();
     assertThat(response).isTrue();
     assertThat(changedParis.userMark()).isEqualTo(PlaceVisitModel.UserMark.NO);
   }
 
   /**
-   * test that changePlaceVisitStatus returns false when PlaceVisitModel object
-   * with the given tripId and placesApiPlaceId is not in storage
+   * test that updateUserMarkOrAddPlaceVisit returns false when PlaceVisitModel object
+   * with the given tripId and uuid is not in storage
    */
   @Test
   public void updateUserMarkOrAddPlaceVisit_placeNotInStorage_returnsFalseAndPlaceAdded()
@@ -239,12 +248,12 @@ public final class InMemoryPlaceVisitStorageTest {
     PlaceVisitModel updatedSeoul =
         SEOUL.toBuilder().setUserMark(PlaceVisitModel.UserMark.NO).build();
     assertThat(response).isFalse();
-    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.placesApiPlaceId()))
+    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.uuid()))
         .hasValue(updatedSeoul);
   }
 
   /**
-   * test that changePlaceVisitStatus returns false when PlaceVisitModel object
+   * test that updateUserMarkOrAddPlaceVisit returns false when PlaceVisitModel object
    * and no PlaceVistModel with same tripId in storage
    */
   @Test
@@ -255,14 +264,14 @@ public final class InMemoryPlaceVisitStorageTest {
     PlaceVisitModel updatedSeoul =
         SEOUL.toBuilder().setUserMark(PlaceVisitModel.UserMark.NO).build();
     assertThat(response).isFalse();
-    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.placesApiPlaceId()))
+    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.uuid()))
         .hasValue(updatedSeoul);
   }
 
   /**
-   * test that changePlaceVisitStatus returns true and userMark field stays same
+   * test that updateUserMarkOrAddPlaceVisit returns true and userMark field stays same
    * when changing status to same status as original PlaceVisitModel
-   * when PlaceVisitModel object with the given tripId and placesApiPlaceId is in storage
+   * when PlaceVisitModel object with the given tripId and placesUuid is in storage
    */
   @Test
   public void updateUserMarkOrAddPlaceVisit_placeInStorage_returnsTrueAndStatusSame()
@@ -274,10 +283,43 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(BEIJING);
 
     boolean response = storage.updateUserMarkOrAddPlaceVisit(PARIS, PlaceVisitModel.UserMark.MAYBE);
-    PlaceVisitModel changedParis =
-        storage.getPlaceVisit(PARIS.tripId(), PARIS.placesApiPlaceId()).get();
+    PlaceVisitModel changedParis = storage.getPlaceVisit(PARIS.tripId(), PARIS.uuid()).get();
     assertThat(response).isTrue();
     assertThat(changedParis.userMark()).isEqualTo(PlaceVisitModel.UserMark.MAYBE);
+  }
+
+  /**
+   * test that updateUserMark changes the userMark field when PlaceVisitModel object
+   * with given tripId and placesUuid is in storage
+   */
+  @Test
+  public void updateUserMark_placeInStorage_returnsPlaceVisitWithUpdatedStatus()
+      throws PlaceVisitAlreadyExistsException, PlaceVisitNotFoundException {
+    InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
+    storage.addPlaceVisit(LONDON);
+    storage.addPlaceVisit(PARIS);
+    storage.addPlaceVisit(ROME);
+    storage.addPlaceVisit(BEIJING);
+
+    PlaceVisitModel changedParis =
+        storage.updateUserMark(PARIS.tripId(), PARIS.uuid(), PlaceVisitModel.UserMark.NO);
+    PlaceVisitModel expectedParis =
+        PARIS.toBuilder().setUserMark(PlaceVisitModel.UserMark.NO).build();
+
+    assertThat(changedParis).isEqualTo(expectedParis);
+  }
+
+  @Test
+  public void updateUserMark_placeNotInStorage_throwsError()
+      throws PlaceVisitAlreadyExistsException, PlaceVisitNotFoundException {
+    InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
+    storage.addPlaceVisit(LONDON);
+    storage.addPlaceVisit(PARIS);
+    storage.addPlaceVisit(ROME);
+    storage.addPlaceVisit(BEIJING);
+
+    Assert.assertThrows(PlaceVisitNotFoundException.class,
+        () -> storage.updateUserMark(SEOUL.tripId(), SEOUL.uuid(), PlaceVisitModel.UserMark.NO));
   }
 
   /**

--- a/frontend/src/test/java/com/google/sps/InMemoryPlaceVisitStorageTest.java
+++ b/frontend/src/test/java/com/google/sps/InMemoryPlaceVisitStorageTest.java
@@ -131,12 +131,10 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(TOKYO);
     storage.addPlaceVisit(TOKYO_B);
 
-    Optional<PlaceVisitModel> tokyo =
-        storage.getPlaceVisit(TOKYO.tripId(), TOKYO.id());
+    Optional<PlaceVisitModel> tokyo = storage.getPlaceVisit(TOKYO.tripId(), TOKYO.id());
     assertThat(tokyo).hasValue(TOKYO);
 
-    Optional<PlaceVisitModel> tokyoB =
-        storage.getPlaceVisit(TOKYO_B.tripId(), TOKYO_B.id());
+    Optional<PlaceVisitModel> tokyoB = storage.getPlaceVisit(TOKYO_B.tripId(), TOKYO_B.id());
     assertThat(tokyoB).hasValue(TOKYO_B);
   }
 
@@ -210,8 +208,7 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(BEIJING);
 
     boolean response = storage.updateUserMarkOrAddPlaceVisit(PARIS, PlaceVisitModel.UserMark.NO);
-    PlaceVisitModel changedParis =
-        storage.getPlaceVisit(PARIS.tripId(), PARIS.id()).get();
+    PlaceVisitModel changedParis = storage.getPlaceVisit(PARIS.tripId(), PARIS.id()).get();
     assertThat(response).isTrue();
     assertThat(changedParis.userMark()).isEqualTo(PlaceVisitModel.UserMark.NO);
   }
@@ -232,8 +229,7 @@ public final class InMemoryPlaceVisitStorageTest {
     PlaceVisitModel updatedSeoul =
         SEOUL.toBuilder().setUserMark(PlaceVisitModel.UserMark.NO).build();
     assertThat(response).isFalse();
-    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.id()))
-        .hasValue(updatedSeoul);
+    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.id())).hasValue(updatedSeoul);
   }
 
   /**
@@ -248,8 +244,7 @@ public final class InMemoryPlaceVisitStorageTest {
     PlaceVisitModel updatedSeoul =
         SEOUL.toBuilder().setUserMark(PlaceVisitModel.UserMark.NO).build();
     assertThat(response).isFalse();
-    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.id()))
-        .hasValue(updatedSeoul);
+    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.id())).hasValue(updatedSeoul);
   }
 
   /**

--- a/frontend/src/test/java/com/google/sps/InMemoryPlaceVisitStorageTest.java
+++ b/frontend/src/test/java/com/google/sps/InMemoryPlaceVisitStorageTest.java
@@ -289,40 +289,6 @@ public final class InMemoryPlaceVisitStorageTest {
   }
 
   /**
-   * test that updateUserMark changes the userMark field when PlaceVisitModel object
-   * with given tripId and placesUuid is in storage
-   */
-  @Test
-  public void updateUserMark_placeInStorage_returnsPlaceVisitWithUpdatedStatus()
-      throws PlaceVisitAlreadyExistsException, PlaceVisitNotFoundException {
-    InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
-    storage.addPlaceVisit(LONDON);
-    storage.addPlaceVisit(PARIS);
-    storage.addPlaceVisit(ROME);
-    storage.addPlaceVisit(BEIJING);
-
-    PlaceVisitModel changedParis =
-        storage.updateUserMark(PARIS.tripId(), PARIS.uuid(), PlaceVisitModel.UserMark.NO);
-    PlaceVisitModel expectedParis =
-        PARIS.toBuilder().setUserMark(PlaceVisitModel.UserMark.NO).build();
-
-    assertThat(changedParis).isEqualTo(expectedParis);
-  }
-
-  @Test
-  public void updateUserMark_placeNotInStorage_throwsError()
-      throws PlaceVisitAlreadyExistsException, PlaceVisitNotFoundException {
-    InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
-    storage.addPlaceVisit(LONDON);
-    storage.addPlaceVisit(PARIS);
-    storage.addPlaceVisit(ROME);
-    storage.addPlaceVisit(BEIJING);
-
-    Assert.assertThrows(PlaceVisitNotFoundException.class,
-        () -> storage.updateUserMark(SEOUL.tripId(), SEOUL.uuid(), PlaceVisitModel.UserMark.NO));
-  }
-
-  /**
    * test that only the PlaceVisitModel objects with the given tripId and
    * userMark of "must-see" or "if-time" are returned in list when there is only
    * one unique tripId in storage

--- a/frontend/src/test/java/com/google/sps/InMemoryPlaceVisitStorageTest.java
+++ b/frontend/src/test/java/com/google/sps/InMemoryPlaceVisitStorageTest.java
@@ -19,88 +19,72 @@ import org.junit.runners.JUnit4;
 public final class InMemoryPlaceVisitStorageTest {
   // PlaceVisitModel objects to use in testing
   private static final PlaceVisitModel LONDON = PlaceVisitModel.builder()
-                                                    .setUuid("LCY, London")
+                                                    .setId("LCY, London")
                                                     .setPlacesApiPlaceId("LCY")
                                                     .setPlaceName("London, UK")
                                                     .setTripId("a")
                                                     .setUserMark(PlaceVisitModel.UserMark.NO)
-                                                    .setLatitude(56.0)
-                                                    .setLongitude(23.64)
                                                     .build();
 
   private static final PlaceVisitModel ROME = PlaceVisitModel.builder()
-                                                  .setUuid("FCO, Rome")
+                                                  .setId("FCO, Rome")
                                                   .setPlacesApiPlaceId("FCO")
                                                   .setPlaceName("Rome, Italy")
                                                   .setTripId("a")
                                                   .setUserMark(PlaceVisitModel.UserMark.YES)
-                                                  .setLatitude(44.32)
-                                                  .setLongitude(32.1244)
                                                   .build();
 
   private static final PlaceVisitModel PARIS = PlaceVisitModel.builder()
-                                                   .setUuid("CDG, Paris")
+                                                   .setId("CDG, Paris")
                                                    .setPlacesApiPlaceId("CDG")
                                                    .setPlaceName("Paris, France")
                                                    .setTripId("a")
                                                    .setUserMark(PlaceVisitModel.UserMark.MAYBE)
-                                                   .setLatitude(48.3288)
-                                                   .setLongitude(34.0)
                                                    .build();
 
   private static final PlaceVisitModel TOKYO = PlaceVisitModel.builder()
-                                                   .setUuid("HND, Tokyo")
+                                                   .setId("HND, Tokyo")
                                                    .setPlacesApiPlaceId("HND")
                                                    .setPlaceName("Tokyo, Japan")
                                                    .setTripId("a")
                                                    .setUserMark(PlaceVisitModel.UserMark.YES)
-                                                   .setLatitude(35.32)
-                                                   .setLongitude(139.33)
                                                    .build();
 
   private static final PlaceVisitModel BEIJING = PlaceVisitModel.builder()
-                                                     .setUuid("PEK, Beijing")
+                                                     .setId("PEK, Beijing")
                                                      .setPlacesApiPlaceId("PEK")
                                                      .setPlaceName("Beijing, China")
                                                      .setTripId("b")
                                                      .setUserMark(PlaceVisitModel.UserMark.YES)
-                                                     .setLatitude(35.32)
-                                                     .setLongitude(125.33)
                                                      .build();
 
   private static final PlaceVisitModel SEOUL = PlaceVisitModel.builder()
-                                                   .setUuid("ICN, Seoul")
+                                                   .setId("ICN, Seoul")
                                                    .setPlacesApiPlaceId("ICN")
                                                    .setPlaceName("Seoul, South Korea")
                                                    .setTripId("b")
                                                    .setUserMark(PlaceVisitModel.UserMark.MAYBE)
-                                                   .setLatitude(26.32)
-                                                   .setLongitude(135.33)
                                                    .build();
 
   private static final PlaceVisitModel TOKYO_B = PlaceVisitModel.builder()
-                                                     .setUuid("HND, Tokyo")
+                                                     .setId("HND, Tokyo")
                                                      .setPlacesApiPlaceId("HND")
                                                      .setPlaceName("Tokyo, Japan")
                                                      .setTripId("b")
                                                      .setUserMark(PlaceVisitModel.UserMark.YES)
-                                                     .setLatitude(35.32)
-                                                     .setLongitude(139.33)
                                                      .build();
 
   private static final PlaceVisitModel SEOUL_B = PlaceVisitModel.builder()
-                                                     .setUuid("ICN, Seoul")
+                                                     .setId("ICN, Seoul")
                                                      .setPlacesApiPlaceId("ICN")
                                                      .setPlaceName("some city in Korea")
                                                      .setTripId("b")
                                                      .setUserMark(PlaceVisitModel.UserMark.MAYBE)
-                                                     .setLatitude(0.0)
-                                                     .setLongitude(0.0)
                                                      .build();
 
   /**
    * test that a PlaceVisitAlreadyExistsException is thrown when a place is
-   * added but another place with the same uuid and tripId has already
+   * added but another place with the same id and tripId has already
    * been added to the storage
    */
   @Test
@@ -119,13 +103,13 @@ public final class InMemoryPlaceVisitStorageTest {
   @Test
   public void getPlaceVisit_emptyStorage_returnsEmptyOptional() {
     InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
-    assertThat(storage.getPlaceVisit(TOKYO.tripId(), TOKYO.uuid())).isEmpty();
+    assertThat(storage.getPlaceVisit(TOKYO.tripId(), TOKYO.id())).isEmpty();
   }
 
   /**
    * test that a PlaceNotFoundException is thrown when trying to get a place
    * from storage when there is no place in storage with the given tripId and
-   * uuid
+   * id
    */
   @Test
   public void getPlaceVisit_placeNotInStorage_returnsEmptyOptional()
@@ -133,7 +117,7 @@ public final class InMemoryPlaceVisitStorageTest {
     InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
     storage.addPlaceVisit(TOKYO);
     storage.addPlaceVisit(TOKYO_B);
-    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.uuid())).isEmpty();
+    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.id())).isEmpty();
   }
 
   /**
@@ -148,11 +132,11 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(TOKYO_B);
 
     Optional<PlaceVisitModel> tokyo =
-        storage.getPlaceVisit(TOKYO.tripId(), TOKYO.uuid());
+        storage.getPlaceVisit(TOKYO.tripId(), TOKYO.id());
     assertThat(tokyo).hasValue(TOKYO);
 
     Optional<PlaceVisitModel> tokyoB =
-        storage.getPlaceVisit(TOKYO_B.tripId(), TOKYO_B.uuid());
+        storage.getPlaceVisit(TOKYO_B.tripId(), TOKYO_B.id());
     assertThat(tokyoB).hasValue(TOKYO_B);
   }
 
@@ -164,13 +148,13 @@ public final class InMemoryPlaceVisitStorageTest {
   public void removePlaceVisit_emptyStorage_throwsException() throws PlaceVisitNotFoundException {
     InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
     Assert.assertThrows(PlaceVisitNotFoundException.class,
-        () -> storage.removePlaceVisit(TOKYO.tripId(), TOKYO.uuid()));
+        () -> storage.removePlaceVisit(TOKYO.tripId(), TOKYO.id()));
   }
 
   /**
    * test that a PlaceNotFoundException is thrown when trying to remove a place
    * from storage when there is no place in storage with the given tripId and
-   * uuid
+   * id
    */
   @Test
   public void removePlaceVisit_placeNotInStorage_throwsException()
@@ -179,12 +163,12 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(TOKYO);
     storage.addPlaceVisit(TOKYO_B);
     Assert.assertThrows(PlaceVisitNotFoundException.class,
-        () -> storage.removePlaceVisit(SEOUL.tripId(), SEOUL.uuid()));
+        () -> storage.removePlaceVisit(SEOUL.tripId(), SEOUL.id()));
   }
 
   /**
    * test that no exception is thrown when removing a place from storage when
-   * there is a place in storage with the given tripId and uuid
+   * there is a place in storage with the given tripId and id
    */
   @Test
   public void removePlace_placeInStorage_noException()
@@ -192,13 +176,13 @@ public final class InMemoryPlaceVisitStorageTest {
     InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
     storage.addPlaceVisit(ROME);
     storage.addPlaceVisit(BEIJING);
-    storage.removePlaceVisit(ROME.tripId(), ROME.uuid());
+    storage.removePlaceVisit(ROME.tripId(), ROME.id());
   }
 
   /**
    * test that place is actually removed when removing a place from storage when
-   * there is a place in storage with the given tripId and uuid by checking
-   * that calling getPlaceVisit on the removed PlaceVisit tripId and uuid
+   * there is a place in storage with the given tripId and id by checking
+   * that calling getPlaceVisit on the removed PlaceVisit tripId and id
    * results in PlaceVisitNotFoundException being thrown
    */
   @Test
@@ -207,14 +191,14 @@ public final class InMemoryPlaceVisitStorageTest {
     InMemoryPlaceVisitStorage storage = new InMemoryPlaceVisitStorage();
     storage.addPlaceVisit(ROME);
     storage.addPlaceVisit(BEIJING);
-    storage.removePlaceVisit(ROME.tripId(), ROME.uuid());
-    assertThat(storage.getPlaceVisit(ROME.tripId(), ROME.uuid())).isEmpty();
+    storage.removePlaceVisit(ROME.tripId(), ROME.id());
+    assertThat(storage.getPlaceVisit(ROME.tripId(), ROME.id())).isEmpty();
   }
 
   /**
    * test that updateUserMarkOrAddPlaceVisit returns true and changes userMark field
    * and returns true when PlaceVisitModel object with the given tripId and
-   * uuid is in storage
+   * id is in storage
    */
   @Test
   public void updateUserMarkOrAddPlaceVisit_placeInStorage_returnsTrueAndStatusChanged()
@@ -227,14 +211,14 @@ public final class InMemoryPlaceVisitStorageTest {
 
     boolean response = storage.updateUserMarkOrAddPlaceVisit(PARIS, PlaceVisitModel.UserMark.NO);
     PlaceVisitModel changedParis =
-        storage.getPlaceVisit(PARIS.tripId(), PARIS.uuid()).get();
+        storage.getPlaceVisit(PARIS.tripId(), PARIS.id()).get();
     assertThat(response).isTrue();
     assertThat(changedParis.userMark()).isEqualTo(PlaceVisitModel.UserMark.NO);
   }
 
   /**
    * test that updateUserMarkOrAddPlaceVisit returns false when PlaceVisitModel object
-   * with the given tripId and uuid is not in storage
+   * with the given tripId and id is not in storage
    */
   @Test
   public void updateUserMarkOrAddPlaceVisit_placeNotInStorage_returnsFalseAndPlaceAdded()
@@ -248,7 +232,7 @@ public final class InMemoryPlaceVisitStorageTest {
     PlaceVisitModel updatedSeoul =
         SEOUL.toBuilder().setUserMark(PlaceVisitModel.UserMark.NO).build();
     assertThat(response).isFalse();
-    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.uuid()))
+    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.id()))
         .hasValue(updatedSeoul);
   }
 
@@ -264,14 +248,14 @@ public final class InMemoryPlaceVisitStorageTest {
     PlaceVisitModel updatedSeoul =
         SEOUL.toBuilder().setUserMark(PlaceVisitModel.UserMark.NO).build();
     assertThat(response).isFalse();
-    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.uuid()))
+    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.id()))
         .hasValue(updatedSeoul);
   }
 
   /**
    * test that updateUserMarkOrAddPlaceVisit returns true and userMark field stays same
    * when changing status to same status as original PlaceVisitModel
-   * when PlaceVisitModel object with the given tripId and placesUuid is in storage
+   * when PlaceVisitModel object with the given tripId and places id is in storage
    */
   @Test
   public void updateUserMarkOrAddPlaceVisit_placeInStorage_returnsTrueAndStatusSame()
@@ -283,7 +267,7 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(BEIJING);
 
     boolean response = storage.updateUserMarkOrAddPlaceVisit(PARIS, PlaceVisitModel.UserMark.MAYBE);
-    PlaceVisitModel changedParis = storage.getPlaceVisit(PARIS.tripId(), PARIS.uuid()).get();
+    PlaceVisitModel changedParis = storage.getPlaceVisit(PARIS.tripId(), PARIS.id()).get();
     assertThat(response).isTrue();
     assertThat(changedParis.userMark()).isEqualTo(PlaceVisitModel.UserMark.MAYBE);
   }

--- a/frontend/src/test/java/com/google/tripmeout/frontend/servlet/ServletUtilTest.java
+++ b/frontend/src/test/java/com/google/tripmeout/frontend/servlet/ServletUtilTest.java
@@ -61,10 +61,6 @@ public class ServletUtilTest {
   @Test
   public void extractFromRequestBody_supplyTripObject_returnsOptionalTrip()
       throws IOException, EmptyRequestBodyException {
-    when(request.getReader())
-        .thenReturn(new BufferedReader(new StringReader(
-            "{id: abc123, name: trip1, userId: a, locationLat: 33.2, locationLong: -22.77}")));
-
     TripModel testTrip = TripModel.builder()
                              .setId("abc123")
                              .setName("trip1")
@@ -73,6 +69,9 @@ public class ServletUtilTest {
                              .setLocationLong(-22.77)
                              .build();
 
+    when(request.getReader())
+        .thenReturn(new BufferedReader(new StringReader(gson.toJson(testTrip))));
+
     assertThat(ServletUtil.extractFromRequestBody(request.getReader(), gson, TripModel.class))
         .isEqualTo(testTrip);
   }
@@ -80,10 +79,10 @@ public class ServletUtilTest {
   @Test
   public void extractFromRequestBody_supplyTripObjectNotAllFields_returnsOptionalTrip()
       throws IOException, EmptyRequestBodyException {
-    when(request.getReader())
-        .thenReturn(new BufferedReader(new StringReader("{name: abc123, userId: a}")));
-
     TripModel testTrip = TripModel.builder().setName("abc123").setUserId("a").build();
+
+    when(request.getReader())
+        .thenReturn(new BufferedReader(new StringReader(gson.toJson(testTrip))));
 
     assertThat(ServletUtil.extractFromRequestBody(request.getReader(), gson, TripModel.class))
         .isEqualTo(testTrip);
@@ -92,9 +91,7 @@ public class ServletUtilTest {
   @Test
   public void extractFromRequestBody_missingName_throwsError()
       throws IOException, EmptyRequestBodyException {
-    when(request.getReader())
-        .thenReturn(new BufferedReader(
-            new StringReader("{id: a, locationLat: 33.2, locationLong: -22.77}")));
+    when(request.getReader()).thenReturn(new BufferedReader(new StringReader("{id: a}")));
     assertThrows(JsonParseException.class,
         () -> ServletUtil.extractFromRequestBody(request.getReader(), gson, TripModel.class));
   }

--- a/frontend/src/test/java/com/google/tripmeout/frontend/servlet/ServletUtilTest.java
+++ b/frontend/src/test/java/com/google/tripmeout/frontend/servlet/ServletUtilTest.java
@@ -104,15 +104,13 @@ public class ServletUtilTest {
       throws IOException, EmptyRequestBodyException {
     when(request.getReader())
         .thenReturn(new BufferedReader(new StringReader(
-            "{tripId: abc123, placesApiPlaceId: 123, placeName: trip1, userMark: YES, latitude: 33.2, longitude: -22.77}")));
+            "{tripId: abc123, placesApiPlaceId: 123, placeName: trip1, userMark: YES}")));
 
     PlaceVisitModel testPlace1 = PlaceVisitModel.builder()
                                      .setTripId("abc123")
                                      .setPlacesApiPlaceId("123")
                                      .setPlaceName("trip1")
                                      .setUserMark(PlaceVisitModel.UserMark.YES)
-                                     .setLatitude(33.2)
-                                     .setLongitude(-22.77)
                                      .build();
 
     assertThat(ServletUtil.extractFromRequestBody(request.getReader(), gson, PlaceVisitModel.class))

--- a/frontend/src/test/java/com/google/tripmeout/serialization/GsonPlaceVisitTypeAdapterTest.java
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/GsonPlaceVisitTypeAdapterTest.java
@@ -19,7 +19,6 @@ public class GsonPlaceVisitTypeAdapterTest {
   private Gson gson;
 
   private PlaceVisitModel basePlaceVisit = PlaceVisitModel.builder()
-                                               .setTripId("123")
                                                .setPlacesApiPlaceId("ABC")
                                                .setUserMark(PlaceVisitModel.UserMark.YES)
                                                .build();
@@ -37,7 +36,9 @@ public class GsonPlaceVisitTypeAdapterTest {
     PlaceVisitModel place =
         gson.fromJson(TestDataAccessUtil.getWellFormedPlaceVisit(), PlaceVisitModel.class);
     PlaceVisitModel expected = basePlaceVisit.toBuilder()
+                                   .setUuid("abc123")
                                    .setPlaceName("New York")
+                                   .setTripId("123")
                                    .setLatitude(50.2)
                                    .setLongitude(39.1)
                                    .build();
@@ -54,7 +55,7 @@ public class GsonPlaceVisitTypeAdapterTest {
   }
 
   @Test
-  public void deserialize_noPlaceId_throwsJsonParseException() throws Exception {
+  public void deserialize_noPlacesApiPlaceId_throwsJsonParseException() throws Exception {
     assertThrows(JsonParseException.class,
         ()
             -> gson.fromJson(
@@ -66,18 +67,29 @@ public class GsonPlaceVisitTypeAdapterTest {
     PlaceVisitModel place =
         gson.fromJson(TestDataAccessUtil.getPlaceVisitWithoutName(), PlaceVisitModel.class);
 
-    PlaceVisitModel expected =
-        basePlaceVisit.toBuilder().setLatitude(50.2).setLongitude(39.1).build();
+    PlaceVisitModel expected = basePlaceVisit.toBuilder()
+                                   .setUuid("abc123")
+                                   .setTripId("123")
+                                   .setLatitude(50.2)
+                                   .setLongitude(39.1)
+                                   .build();
 
     assertThat(place).isEqualTo(expected);
   }
 
   @Test
-  public void deserialize_noTripId_throwsJsonParseException() throws Exception {
-    assertThrows(JsonParseException.class,
-        ()
-            -> gson.fromJson(
-                TestDataAccessUtil.getPlaceVisitWithoutTripId(), PlaceVisitModel.class));
+  public void deserialize_noTripId_returnsPlaceVisitWithNullTripId() throws Exception {
+    PlaceVisitModel place =
+        gson.fromJson(TestDataAccessUtil.getPlaceVisitWithoutTripId(), PlaceVisitModel.class);
+
+    PlaceVisitModel expected = basePlaceVisit.toBuilder()
+                                   .setUuid("abc123")
+                                   .setPlaceName("New York")
+                                   .setLatitude(50.2)
+                                   .setLongitude(39.1)
+                                   .build();
+
+    assertThat(place).isEqualTo(expected);
   }
 
   @Test
@@ -85,8 +97,12 @@ public class GsonPlaceVisitTypeAdapterTest {
     PlaceVisitModel place =
         gson.fromJson(TestDataAccessUtil.getPlaceVisitWithoutLatitude(), PlaceVisitModel.class);
 
-    PlaceVisitModel expected =
-        basePlaceVisit.toBuilder().setPlaceName("New York").setLongitude(39.1).build();
+    PlaceVisitModel expected = basePlaceVisit.toBuilder()
+                                   .setUuid("abc123")
+                                   .setTripId("123")
+                                   .setPlaceName("New York")
+                                   .setLongitude(39.1)
+                                   .build();
 
     assertThat(place).isEqualTo(expected);
   }
@@ -96,8 +112,12 @@ public class GsonPlaceVisitTypeAdapterTest {
     PlaceVisitModel place =
         gson.fromJson(TestDataAccessUtil.getPlaceVisitWithoutLongitude(), PlaceVisitModel.class);
 
-    PlaceVisitModel expected =
-        basePlaceVisit.toBuilder().setPlaceName("New York").setLatitude(50.2).build();
+    PlaceVisitModel expected = basePlaceVisit.toBuilder()
+                                   .setUuid("abc123")
+                                   .setTripId("123")
+                                   .setPlaceName("New York")
+                                   .setLatitude(50.2)
+                                   .build();
 
     assertThat(place).isEqualTo(expected);
   }

--- a/frontend/src/test/java/com/google/tripmeout/serialization/GsonPlaceVisitTypeAdapterTest.java
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/GsonPlaceVisitTypeAdapterTest.java
@@ -65,10 +65,7 @@ public class GsonPlaceVisitTypeAdapterTest {
     PlaceVisitModel place =
         gson.fromJson(TestDataAccessUtil.getPlaceVisitWithoutName(), PlaceVisitModel.class);
 
-    PlaceVisitModel expected = basePlaceVisit.toBuilder()
-                                   .setId("abc123")
-                                   .setTripId("123")
-                                   .build();
+    PlaceVisitModel expected = basePlaceVisit.toBuilder().setId("abc123").setTripId("123").build();
 
     assertThat(place).isEqualTo(expected);
   }
@@ -78,10 +75,8 @@ public class GsonPlaceVisitTypeAdapterTest {
     PlaceVisitModel place =
         gson.fromJson(TestDataAccessUtil.getPlaceVisitWithoutTripId(), PlaceVisitModel.class);
 
-    PlaceVisitModel expected = basePlaceVisit.toBuilder()
-                                   .setId("abc123")
-                                   .setPlaceName("New York")
-                                   .build();
+    PlaceVisitModel expected =
+        basePlaceVisit.toBuilder().setId("abc123").setPlaceName("New York").build();
 
     assertThat(place).isEqualTo(expected);
   }

--- a/frontend/src/test/java/com/google/tripmeout/serialization/GsonPlaceVisitTypeAdapterTest.java
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/GsonPlaceVisitTypeAdapterTest.java
@@ -36,11 +36,9 @@ public class GsonPlaceVisitTypeAdapterTest {
     PlaceVisitModel place =
         gson.fromJson(TestDataAccessUtil.getWellFormedPlaceVisit(), PlaceVisitModel.class);
     PlaceVisitModel expected = basePlaceVisit.toBuilder()
-                                   .setUuid("abc123")
+                                   .setId("abc123")
                                    .setPlaceName("New York")
                                    .setTripId("123")
-                                   .setLatitude(50.2)
-                                   .setLongitude(39.1)
                                    .build();
 
     assertThat(place).isEqualTo(expected);
@@ -68,10 +66,8 @@ public class GsonPlaceVisitTypeAdapterTest {
         gson.fromJson(TestDataAccessUtil.getPlaceVisitWithoutName(), PlaceVisitModel.class);
 
     PlaceVisitModel expected = basePlaceVisit.toBuilder()
-                                   .setUuid("abc123")
+                                   .setId("abc123")
                                    .setTripId("123")
-                                   .setLatitude(50.2)
-                                   .setLongitude(39.1)
                                    .build();
 
     assertThat(place).isEqualTo(expected);
@@ -83,40 +79,8 @@ public class GsonPlaceVisitTypeAdapterTest {
         gson.fromJson(TestDataAccessUtil.getPlaceVisitWithoutTripId(), PlaceVisitModel.class);
 
     PlaceVisitModel expected = basePlaceVisit.toBuilder()
-                                   .setUuid("abc123")
+                                   .setId("abc123")
                                    .setPlaceName("New York")
-                                   .setLatitude(50.2)
-                                   .setLongitude(39.1)
-                                   .build();
-
-    assertThat(place).isEqualTo(expected);
-  }
-
-  @Test
-  public void deserialize_noLatitude_returnsPlaceVisitWithNullLatitude() throws Exception {
-    PlaceVisitModel place =
-        gson.fromJson(TestDataAccessUtil.getPlaceVisitWithoutLatitude(), PlaceVisitModel.class);
-
-    PlaceVisitModel expected = basePlaceVisit.toBuilder()
-                                   .setUuid("abc123")
-                                   .setTripId("123")
-                                   .setPlaceName("New York")
-                                   .setLongitude(39.1)
-                                   .build();
-
-    assertThat(place).isEqualTo(expected);
-  }
-
-  @Test
-  public void deserialize_noLongitude_returnsPlaceVisitWithNullLongitude() throws Exception {
-    PlaceVisitModel place =
-        gson.fromJson(TestDataAccessUtil.getPlaceVisitWithoutLongitude(), PlaceVisitModel.class);
-
-    PlaceVisitModel expected = basePlaceVisit.toBuilder()
-                                   .setUuid("abc123")
-                                   .setTripId("123")
-                                   .setPlaceName("New York")
-                                   .setLatitude(50.2)
                                    .build();
 
     assertThat(place).isEqualTo(expected);
@@ -128,8 +92,6 @@ public class GsonPlaceVisitTypeAdapterTest {
                                 .setPlacesApiPlaceId("abc")
                                 .setPlaceName("name")
                                 .setTripId("tripId")
-                                .setLongitude(12.3)
-                                .setLatitude(34.9)
                                 .build();
     assertThat(gson.fromJson(gson.toJson(place), PlaceVisitModel.class)).isEqualTo(place);
   }

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithUnknownField.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithUnknownField.json
@@ -1,10 +1,8 @@
 {
-    "uuid": "abc123",
+    "id": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "tripId":"123",
     "userMark":"YES",
-    "latitude":50.2,
-    "longitude":39.1,
     "Unknown":"random"
 }

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithUnknownField.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithUnknownField.json
@@ -1,4 +1,5 @@
 {
+    "uuid": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "tripId":"123",

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutId.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutId.json
@@ -2,7 +2,5 @@
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "tripId":"123",
-    "userMark":"YES",
-    "latitude":50.2,
-    "longitude":39.1
+    "userMark":"YES"
 }  

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutLatitude.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutLatitude.json
@@ -1,4 +1,5 @@
 {
+    "uuid": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "tripId":"123",

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutLatitude.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutLatitude.json
@@ -1,8 +1,7 @@
 {
-    "uuid": "abc123",
+    "id": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "tripId":"123",
-    "userMark":"YES",
-    "longitude":39.1
+    "userMark":"YES"
 }  

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutLongitude.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutLongitude.json
@@ -1,8 +1,7 @@
 {
-    "uuid": "abc123",
+    "id": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "tripId":"123",
-    "userMark":"YES",
-    "latitude":50.2
+    "userMark":"YES"
 } 

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutLongitude.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutLongitude.json
@@ -1,4 +1,5 @@
 {
+    "uuid": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "tripId":"123",

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutName.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutName.json
@@ -1,8 +1,6 @@
 {
-    "uuid": "abc123",
+    "id": "abc123",
     "placesApiPlaceId":"ABC",
     "tripId":"123",
-    "userMark":"YES",
-    "latitude":50.2,
-    "longitude":39.1
+    "userMark":"YES"
 }  

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutPlaceId.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutPlaceId.json
@@ -1,8 +1,6 @@
 { 
-    "uuid": "abc123",
+    "id": "abc123",
     "placeName":"New York",
     "tripId":"123",
-    "userMark":"YES",
-    "latitude":50.2,
-    "longitude":39.1 
+    "userMark":"YES"
 }

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutPlaceId.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutPlaceId.json
@@ -1,4 +1,5 @@
 { 
+    "uuid": "abc123",
     "placeName":"New York",
     "tripId":"123",
     "userMark":"YES",

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutTripId.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutTripId.json
@@ -1,8 +1,6 @@
 {
-    "uuid": "abc123",
+    "id": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
-    "userMark":"YES",
-    "latitude":50.2,
-    "longitude":39.1
+    "userMark":"YES"
 }  

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutTripId.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutTripId.json
@@ -1,4 +1,5 @@
 {
+    "uuid": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "userMark":"YES",

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutUserMark.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutUserMark.json
@@ -1,8 +1,6 @@
 {
-    "uuid": "abc123",
+    "id": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
-    "tripId":"123",
-    "latitude":50.2,
-    "longitude":39.1
+    "tripId":"123"
 }  

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutUserMark.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutUserMark.json
@@ -1,4 +1,5 @@
 {
+    "uuid": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "tripId":"123",

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutUuid.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/PlaceVisitWithoutUuid.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "abc123",
     "placesApiPlaceId":"ABC",
+    "placeName":"New York",
     "tripId":"123",
     "userMark":"YES",
     "latitude":50.2,

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/WellFormedPlaceVisit.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/WellFormedPlaceVisit.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "abc123",
+    "id": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "tripId":"123",
-    "userMark":"YES",
-    "latitude":50.2,
-    "longitude":39.1
+    "userMark":"YES"
 }  

--- a/frontend/src/test/java/com/google/tripmeout/serialization/testdata/WellFormedPlaceVisit.json
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/testdata/WellFormedPlaceVisit.json
@@ -1,4 +1,5 @@
 {
+    "uuid": "abc123",
     "placesApiPlaceId":"ABC",
     "placeName":"New York",
     "tripId":"123",


### PR DESCRIPTION
I wasn't sure in certain race conditions, namely, if a place visit is deleted while we send a request to update a place visit, whether we want to re-add the place visit to storage or throw an error so I added another method to just update the place and throw an error if it is not in storage