### PR TITLE
Fix pub get resolution for test lib

### DIFF
--- a/frontend/src/test/java/com/google/sps/InMemoryPlaceVisitStorageTest.java
+++ b/frontend/src/test/java/com/google/sps/InMemoryPlaceVisitStorageTest.java
@@ -92,7 +92,7 @@ public final class InMemoryPlaceVisitStorageTest {
 
   /**
    * test that a PlaceVisitAlreadyExistsException is thrown when a place is
-   * added but another place with the same PlacesApiPlaceId and tripId has already 
+   * added but another place with the same PlacesApiPlaceId and tripId has already
    * been added to the storage
    */
   @Test
@@ -139,10 +139,12 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(TOKYO);
     storage.addPlaceVisit(TOKYO_B);
 
-    Optional<PlaceVisitModel> tokyo = storage.getPlaceVisit(TOKYO.tripId(), TOKYO.placesApiPlaceId());
+    Optional<PlaceVisitModel> tokyo =
+        storage.getPlaceVisit(TOKYO.tripId(), TOKYO.placesApiPlaceId());
     assertThat(tokyo).hasValue(TOKYO);
 
-    Optional<PlaceVisitModel> tokyoB = storage.getPlaceVisit(TOKYO_B.tripId(), TOKYO_B.placesApiPlaceId());
+    Optional<PlaceVisitModel> tokyoB =
+        storage.getPlaceVisit(TOKYO_B.tripId(), TOKYO_B.placesApiPlaceId());
     assertThat(tokyoB).hasValue(TOKYO_B);
   }
 
@@ -215,7 +217,8 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(BEIJING);
 
     boolean response = storage.updateUserMarkOrAddPlaceVisit(PARIS, PlaceVisitModel.UserMark.NO);
-    PlaceVisitModel changedParis = storage.getPlaceVisit(PARIS.tripId(), PARIS.placesApiPlaceId()).get();
+    PlaceVisitModel changedParis =
+        storage.getPlaceVisit(PARIS.tripId(), PARIS.placesApiPlaceId()).get();
     assertThat(response).isTrue();
     assertThat(changedParis.userMark()).isEqualTo(PlaceVisitModel.UserMark.NO);
   }
@@ -236,7 +239,8 @@ public final class InMemoryPlaceVisitStorageTest {
     PlaceVisitModel updatedSeoul =
         SEOUL.toBuilder().setUserMark(PlaceVisitModel.UserMark.NO).build();
     assertThat(response).isFalse();
-    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.placesApiPlaceId())).hasValue(updatedSeoul);
+    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.placesApiPlaceId()))
+        .hasValue(updatedSeoul);
   }
 
   /**
@@ -251,7 +255,8 @@ public final class InMemoryPlaceVisitStorageTest {
     PlaceVisitModel updatedSeoul =
         SEOUL.toBuilder().setUserMark(PlaceVisitModel.UserMark.NO).build();
     assertThat(response).isFalse();
-    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.placesApiPlaceId())).hasValue(updatedSeoul);
+    assertThat(storage.getPlaceVisit(SEOUL.tripId(), SEOUL.placesApiPlaceId()))
+        .hasValue(updatedSeoul);
   }
 
   /**
@@ -269,7 +274,8 @@ public final class InMemoryPlaceVisitStorageTest {
     storage.addPlaceVisit(BEIJING);
 
     boolean response = storage.updateUserMarkOrAddPlaceVisit(PARIS, PlaceVisitModel.UserMark.MAYBE);
-    PlaceVisitModel changedParis = storage.getPlaceVisit(PARIS.tripId(), PARIS.placesApiPlaceId()).get();
+    PlaceVisitModel changedParis =
+        storage.getPlaceVisit(PARIS.tripId(), PARIS.placesApiPlaceId()).get();
     assertThat(response).isTrue();
     assertThat(changedParis.userMark()).isEqualTo(PlaceVisitModel.UserMark.MAYBE);
   }

--- a/frontend/src/test/java/com/google/tripmeout/serialization/GsonPlaceVisitTypeAdapterTest.java
+++ b/frontend/src/test/java/com/google/tripmeout/serialization/GsonPlaceVisitTypeAdapterTest.java
@@ -36,8 +36,11 @@ public class GsonPlaceVisitTypeAdapterTest {
   public void deserialize_wellFormed() throws Exception {
     PlaceVisitModel place =
         gson.fromJson(TestDataAccessUtil.getWellFormedPlaceVisit(), PlaceVisitModel.class);
-    PlaceVisitModel expected =
-        basePlaceVisit.toBuilder().setPlaceName("New York").setLatitude(50.2).setLongitude(39.1).build();
+    PlaceVisitModel expected = basePlaceVisit.toBuilder()
+                                   .setPlaceName("New York")
+                                   .setLatitude(50.2)
+                                   .setLongitude(39.1)
+                                   .build();
 
     assertThat(place).isEqualTo(expected);
   }

--- a/frontend/ui/pubspec.yaml
+++ b/frontend/ui/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: ">1.14.7"
   mockito: 4.1.1
 
 # For information on the generic Dart part of this file, see the

--- a/frontend/ui/test/services/in_memory_trip_service_test.dart
+++ b/frontend/ui/test/services/in_memory_trip_service_test.dart
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:tripmeout/services/in_memory_trip_service.dart';
 import 'package:tripmeout/model/trip.dart';
 


### PR DESCRIPTION
Turns out that the flutter_test package hard-codes an internal test_api version. It's tricky to get the exact test version we want such that it resolves the correct transitive dependency, so instead, I've dropped the explicit test dependency. Going forward, tests should use flutter_test directly, which includes the main test libs plus Flutter augmentations.