### PR TITLE
Add servlet request logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ app.*.map.json
 
 # Exceptions to above rules.
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+# Local repo configs
+environment.mk

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,26 @@
+# Local repo configuration configuration. This can be used to overwrite
+# configs/environment variables with persistent defaults. It should not be
+# checked into git.
+-include environment.mk
 
-SHELL=/bin/bash
+CLANG_FORMAT?=clang-format
 DART_CLI?=dart
+FIND?=find
+FLUTTER_APP_ROOT?=frontend/ui
 FLUTTER_CLI?=flutter
 MAVEN_CLI?=mvn
-FLUTTER_APP_ROOT?=frontend/ui
 MAVEN_FRONTEND_ROOT?=frontend
-CLANG_FORMAT?=clang-format
+OPENSSL?=openssl
+SHELL=/bin/bash
 
-# Is there a better way to do this??
-# From https://stackoverflow.com/questions/4036191
-rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
 
 format:
-	$(CLANG_FORMAT) --style=Google -i --sort-includes $(call rwildcard,frontend/,*.java)
+	$(FIND) frontend -name '*.java' -exec $(CLANG_FORMAT) --style=Google -i --sort-includes '{}' +
 	$(DART_CLI) format $(FLUTTER_APP_ROOT)
 
-test-secrets:
+test-secrets: encrypted/ui-maps-places-test.enc
 	mkdir test-secrets
-	openssl aes-256-cbc -d -pbkdf2 -iter 100000 -md sha512 -iv 683df25da352abfd5a5a559505c9034a \
+	$(OPENSSL) aes-256-cbc -d -pbkdf2 -iter 100000 -md sha512 -iv 683df25da352abfd5a5a559505c9034a \
 		-in encrypted/ui-maps-places-test.enc -out test-secrets/ui-maps-places-test
 
 instantiate-html-template-test: test-secrets

--- a/frontend/src/main/java/com/google/tripmeout/frontend/servlet/PlaceVisitIndividualServlet.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/servlet/PlaceVisitIndividualServlet.java
@@ -37,6 +37,8 @@ public class PlaceVisitIndividualServlet extends HttpServlet {
 
   @Override
   public void doPut(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    logger.atInfo().log("%s serving PUT %s", PlaceVisitIndividualServlet.class.getSimpleName(),
+        request.getRequestURI());
     try (PrintWriter writer = response.getWriter()) {
       Matcher matcher = ServletUtil.matchUriOrThrowError(request, URI_NAME_PATTERN);
 
@@ -62,9 +64,10 @@ public class PlaceVisitIndividualServlet extends HttpServlet {
       response.setStatus(HttpServletResponse.SC_OK);
 
     } catch (TripMeOutException e) {
+      logger.atWarning().withCause(e).log("business logic exception");
       response.setStatus(e.restStatusCode());
     } catch (Exception e) {
-      logger.atInfo().log(e.getMessage());
+      logger.atWarning().withCause(e).log("internal error");
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
@@ -72,6 +75,8 @@ public class PlaceVisitIndividualServlet extends HttpServlet {
   @Override
   public void doDelete(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
+    logger.atInfo().log("%s serving DELETE %s", PlaceVisitIndividualServlet.class.getSimpleName(),
+        request.getRequestURI());
     try {
       Matcher matcher = ServletUtil.matchUriOrThrowError(request, URI_NAME_PATTERN);
       String tripId = matcher.group(1);
@@ -81,14 +86,18 @@ public class PlaceVisitIndividualServlet extends HttpServlet {
       response.setStatus(HttpServletResponse.SC_OK);
 
     } catch (TripMeOutException e) {
+      logger.atWarning().withCause(e).log("business logic exception");
       response.setStatus(e.restStatusCode());
     } catch (Exception e) {
+      logger.atWarning().withCause(e).log("internal error");
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    logger.atInfo().log("%s serving GET %s", PlaceVisitIndividualServlet.class.getSimpleName(),
+        request.getRequestURI());
     try (PrintWriter writer = response.getWriter()) {
       Matcher matcher = ServletUtil.matchUriOrThrowError(request, URI_NAME_PATTERN);
       String tripId = matcher.group(1);
@@ -105,8 +114,10 @@ public class PlaceVisitIndividualServlet extends HttpServlet {
       response.setStatus(HttpServletResponse.SC_OK);
 
     } catch (TripMeOutException e) {
+      logger.atWarning().withCause(e).log("business logic exception");
       response.setStatus(e.restStatusCode());
     } catch (Exception e) {
+      logger.atWarning().withCause(e).log("internal error");
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }

--- a/frontend/src/main/java/com/google/tripmeout/frontend/servlet/PlaceVisitParentServlet.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/servlet/PlaceVisitParentServlet.java
@@ -37,6 +37,8 @@ public class PlaceVisitParentServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    logger.atInfo().log("%s serving POST %s", PlaceVisitParentServlet.class.getSimpleName(),
+        request.getRequestURI());
     try (PrintWriter writer = response.getWriter()) {
       PlaceVisitModel place =
           ServletUtil.extractFromRequestBody(request.getReader(), gson, PlaceVisitModel.class);
@@ -55,17 +57,21 @@ public class PlaceVisitParentServlet extends HttpServlet {
       response.setStatus(HttpServletResponse.SC_CREATED);
 
     } catch (TripMeOutException e) {
+      logger.atWarning().withCause(e).log("business logic exception");
       response.setStatus(e.restStatusCode());
     } catch (JsonParseException e) {
+      logger.atWarning().withCause(e).log("business logic exception");
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
     } catch (Exception e) {
-      logger.atWarning().log(e.getMessage());
+      logger.atWarning().withCause(e).log("internal error");
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    logger.atInfo().log("%s serving GET %s", PlaceVisitParentServlet.class.getSimpleName(),
+        request.getRequestURI());
     try (PrintWriter writer = response.getWriter()) {
       String tripId = ServletUtil.matchUriOrThrowError(request, TRIP_NAME_PATTERN).group(1);
       List<PlaceVisitModel> nearbyPlaces = placeStorage.getTripPlaceVisits(tripId);
@@ -73,8 +79,10 @@ public class PlaceVisitParentServlet extends HttpServlet {
       writer.println(gson.toJson(nearbyPlaces));
       response.setStatus(HttpServletResponse.SC_OK);
     } catch (TripMeOutException e) {
+      logger.atWarning().withCause(e).log("business logic exception");
       response.setStatus(e.restStatusCode());
     } catch (Exception e) {
+      logger.atWarning().withCause(e).log("internal error");
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }

--- a/frontend/src/main/java/com/google/tripmeout/frontend/servlet/ServletsModule.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/servlet/ServletsModule.java
@@ -4,12 +4,11 @@ import com.google.inject.servlet.ServletModule;
 
 /**
  * A {@link ServletModule} configured to serve application paths.
- * @see https://github.com/google/guice/wiki/ServletModule
+ * See https://github.com/google/guice/wiki/ServletModule
  */
 public class ServletsModule extends ServletModule {
   @Override
   protected void configureServlets() {
-    // TO-DO: uncomment once servlet is implemented
     serve("/api/trips/*/placeVisits/*").with(PlaceVisitIndividualServlet.class);
     serve("/api/trips/*/placeVisits").with(PlaceVisitParentServlet.class);
     serve("/api/trips/*").with(TripServlet.class);

--- a/frontend/src/main/java/com/google/tripmeout/frontend/servlet/TripParentServlet.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/servlet/TripParentServlet.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonParseException;
 import com.google.inject.Singleton;
 import com.google.tripmeout.frontend.TripModel;
 import com.google.tripmeout.frontend.error.TripMeOutException;
-import com.google.tripmeout.frontend.servlet.ServletUtil;
 import com.google.tripmeout.frontend.storage.TripStorage;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -33,22 +32,24 @@ public class TripParentServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    PrintWriter writer = response.getWriter();
-    try {
+    logger.atInfo().log(
+        "%s serving GET %s", TripParentServlet.class.getSimpleName(), request.getRequestURI());
+    try (PrintWriter writer = response.getWriter()) {
       String userId = getUserId();
       response.setContentType("application/json");
       response.setStatus(HttpServletResponse.SC_OK);
       writer.print(gson.toJson(storage.getAllUserTrips(userId)));
-    } finally {
-      writer.close();
+    } catch (Exception e) {
+      logger.atWarning().withCause(e).log("internal error");
+      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    logger.atInfo().log("received doPost");
-    PrintWriter writer = response.getWriter();
-    try {
+    logger.atInfo().log(
+        "%s serving POST %s", TripParentServlet.class.getSimpleName(), request.getRequestURI());
+    try (PrintWriter writer = response.getWriter()) {
       TripModel requestTrip =
           ServletUtil.extractFromRequestBody(request.getReader(), gson, TripModel.class);
       TripModel resolvedTrip = resolveDefaults(requestTrip);
@@ -56,14 +57,14 @@ public class TripParentServlet extends HttpServlet {
       response.setContentType("application/json");
       writer.println(gson.toJson((resolvedTrip)));
     } catch (TripMeOutException e) {
+      logger.atWarning().withCause(e).log("business logic exception");
       response.setStatus(e.restStatusCode());
     } catch (JsonParseException e) {
+      logger.atWarning().withCause(e).log("bad requst");
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
     } catch (IOException e) {
-      logger.atWarning().withCause(e).log("Error serving post request");
+      logger.atWarning().withCause(e).log("internal error");
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-    } finally {
-      writer.close();
     }
   }
 

--- a/frontend/src/main/java/com/google/tripmeout/frontend/servlet/TripServlet.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/servlet/TripServlet.java
@@ -1,5 +1,6 @@
 package com.google.tripmeout.frontend.servlet;
 
+import com.google.common.flogger.FluentLogger;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -13,9 +14,9 @@ import javax.servlet.http.HttpServletResponse;
 
 @Singleton
 public final class TripServlet extends HttpServlet {
-  // The Trip get and delete servlet
-  private static final long serialVersionUID = 1L;
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
+  private static final long serialVersionUID = 1L;
   private static final String APPLICATION_JSON_CONTENT_TYPE = "application/json;";
 
   private final Gson gson;
@@ -30,6 +31,8 @@ public final class TripServlet extends HttpServlet {
   @Override
   public void doGet(final HttpServletRequest request, final HttpServletResponse response)
       throws IOException {
+    logger.atInfo().log(
+        "%s serving GET %s", TripServlet.class.getSimpleName(), request.getRequestURI());
     try {
       final String tripId = TripName.fromRequestUri(request.getRequestURI()).id();
       TripModel trip = storage.getTrip(tripId);
@@ -37,10 +40,13 @@ public final class TripServlet extends HttpServlet {
       response.getWriter().print(gson.toJson(trip));
       response.getWriter().flush();
     } catch (TripNotFoundException e) {
+      logger.atWarning().withCause(e).log("not found");
       response.setStatus(HttpServletResponse.SC_NOT_FOUND);
     } catch (IllegalArgumentException e) {
+      logger.atWarning().withCause(e).log("bad request");
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
     } catch (Exception e) {
+      logger.atWarning().withCause(e).log("internal error");
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
@@ -48,15 +54,20 @@ public final class TripServlet extends HttpServlet {
   @Override
   public void doDelete(final HttpServletRequest request, final HttpServletResponse response)
       throws IOException {
+    logger.atInfo().log(
+        "%s serving DELETE %s", TripServlet.class.getSimpleName(), request.getRequestURI());
     try {
       final TripName tripName = TripName.fromRequestUri(request.getRequestURI());
       storage.removeTrip(tripName.id());
       response.setStatus(HttpServletResponse.SC_OK);
     } catch (TripNotFoundException e) {
+      logger.atWarning().withCause(e).log("not found");
       response.setStatus(HttpServletResponse.SC_NOT_FOUND);
     } catch (IllegalArgumentException e) {
+      logger.atWarning().withCause(e).log("bad request");
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
     } catch (Exception e) {
+      logger.atWarning().withCause(e).log("internal error");
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }

--- a/frontend/ui/lib/services/place_visit_service.dart
+++ b/frontend/ui/lib/services/place_visit_service.dart
@@ -1,9 +1,9 @@
 import 'package:tripmeout/model/place_visit.dart';
 
 abstract class PlaceVisitService {
-  Future<List<PlaceVisit>> listPlaceVisits(String tripid) async;
-  Future<PlaceVisit> getPlaceVisit(String tripid, String id) async;
-  Future<PlaceVisit> createPlaceVisit(PlaceVisit placeVisit) async;
-  Future<void> deletePlaceVisit(String tripid, String id) async;
-  Future<PlaceVisit> updatePlaceVisitUserMark(PlaceVisit placeVisit) async;
+  Future<List<PlaceVisit>> listPlaceVisits(String tripid);
+  Future<PlaceVisit> getPlaceVisit(String tripid, String id);
+  Future<PlaceVisit> createPlaceVisit(PlaceVisit placeVisit);
+  Future<void> deletePlaceVisit(String tripid, String id);
+  Future<PlaceVisit> updatePlaceVisitUserMark(PlaceVisit placeVisit);
 }


### PR DESCRIPTION
And some general cleanup.

The request logging makes it clear which servlet is answering which request paths, which helps with route/filter debugging.

For example, I was able to see that TripServlet is in fact serving paths that should instead be routed to `PlaceVisitParentServlet` after querying the endpoint through curl:

```
[INFO] GCLOUD: INFO: TripServlet serving GET /api/trips/abc123/placeVisits
```