### PR TITLE
Fix format rule and run formatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 -include environment.mk
 
 CLANG_FORMAT?=clang-format
-DART_CLI?=dart
 FIND?=find
 FLUTTER_APP_ROOT?=frontend/ui
 FLUTTER_CLI?=flutter
@@ -16,7 +15,7 @@ SHELL=/bin/bash
 
 format:
 	$(FIND) frontend -name '*.java' -exec $(CLANG_FORMAT) --style=Google -i --sort-includes '{}' +
-	$(DART_CLI) format $(FLUTTER_APP_ROOT)
+	$(FLUTTER_CLI) format $(FLUTTER_APP_ROOT)
 
 test-secrets: encrypted/ui-maps-places-test.enc
 	mkdir test-secrets

--- a/frontend/ui/lib/widgets/trip_list_widget.dart
+++ b/frontend/ui/lib/widgets/trip_list_widget.dart
@@ -37,13 +37,13 @@ class TripListWidget extends StatelessWidget {
                     context, Router.createTripViewRoute(trip.id));
               },
               trailing: IconButton(
-                    onPressed: () {
-                      _showDialog(context);
-                    },
-                    icon: Icon(Icons.delete),
-                    color: Colors.red,
-                    tooltip: 'Click here to delete trip.',
-                  ),
+                onPressed: () {
+                  _showDialog(context);
+                },
+                icon: Icon(Icons.delete),
+                color: Colors.red,
+                tooltip: 'Click here to delete trip.',
+              ),
             ))
         .toList();
     return ListView(children: listItems);


### PR DESCRIPTION
Looks like the `dart` no longer supports the `format` subcommand. Not sure if that was an oversight, but switching back to `flutter format` in the latest release no longer issues deprecation warnings.