### PR TITLE
Fix servlet subpath routing

### DIFF
--- a/frontend/src/main/java/com/google/tripmeout/frontend/servlet/ServletsModule.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/servlet/ServletsModule.java
@@ -9,9 +9,9 @@ import com.google.inject.servlet.ServletModule;
 public class ServletsModule extends ServletModule {
   @Override
   protected void configureServlets() {
-    serve("/api/trips/*/placeVisits/*").with(PlaceVisitIndividualServlet.class);
-    serve("/api/trips/*/placeVisits").with(PlaceVisitParentServlet.class);
-    serve("/api/trips/*").with(TripServlet.class);
+    serveRegex("/api/trips/[^/]+/placeVisits/[^/]+").with(PlaceVisitIndividualServlet.class);
+    serveRegex("/api/trips/[^/]+/placeVisits").with(PlaceVisitParentServlet.class);
+    serveRegex("/api/trips/[^/]+").with(TripServlet.class);
     serve("/api/trips").with(TripParentServlet.class);
   }
 }


### PR DESCRIPTION
Using regex serving paths seems to fix servlet resolution. I'm not sure why, but it's possible that * matches all characters (including path separators) in standard path syntax.

Create-visit requests fail for me due to Maps not accepting the API key, but routing seems to be fixed.