### PR TITLE
Return error on invalid request paths

### DIFF
--- a/frontend/src/main/java/com/google/tripmeout/frontend/servlet/InvalidPathServlet.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/servlet/InvalidPathServlet.java
@@ -1,0 +1,18 @@
+package com.google.tripmeout.frontend.servlet;
+
+import com.google.common.flogger.FluentLogger;
+import javax.inject.Singleton;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Singleton
+public class InvalidPathServlet extends HttpServlet {
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  @Override
+  protected void service(HttpServletRequest req, HttpServletResponse resp) {
+    logger.atWarning().log("Invalid request path: %s %s", req.getMethod(), req.getRequestURI());
+    resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
+}

--- a/frontend/src/main/java/com/google/tripmeout/frontend/servlet/ServletsModule.java
+++ b/frontend/src/main/java/com/google/tripmeout/frontend/servlet/ServletsModule.java
@@ -12,6 +12,7 @@ public class ServletsModule extends ServletModule {
     serveRegex("/api/trips/[^/]+/placeVisits/[^/]+").with(PlaceVisitIndividualServlet.class);
     serveRegex("/api/trips/[^/]+/placeVisits").with(PlaceVisitParentServlet.class);
     serveRegex("/api/trips/[^/]+").with(TripServlet.class);
-    serve("/api/trips").with(TripParentServlet.class);
+    serveRegex("/api/trips").with(TripParentServlet.class);
+    serveRegex("/api(?:/.*)?").with(InvalidPathServlet.class);
   }
 }


### PR DESCRIPTION
The servlet filter falls back to serving the index page for unmatched request paths. This adds a servlet that returns BAD_REQUEST for all invalid /api request paths.